### PR TITLE
feat(models) : Tag - replace isValidated by state

### DIFF
--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  testing:
+  build-oas-artefacts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,7 +14,6 @@ jobs:
       - name: Install required tools
         run: |
           npm install speccy -g
-          npm install openapi-diff -g
           npm install -g @openapitools/openapi-generator-cli
       - name: Set up env variables
         run:  |
@@ -34,15 +33,35 @@ jobs:
         run: |
           npx speccy resolve A/api.yml -o original-spec.yaml
           npx speccy resolve B/api.yml -o modified-spec.yaml
-      - uses: actions/upload-artifact@v1
+      - name: Upload single OAS file from ${{ env.TARGET_BRANCH }}
+        uses: actions/upload-artifact@v1
         with:
           name: original-spec.yaml
           path: original-spec.yaml
-      - uses: actions/upload-artifact@v1
+      - name: Upload single OAS file from ${{ env.CURRENT_BRANCH }}
+        uses: actions/upload-artifact@v1
         with:
           name: modified-spec.yaml
           path: modified-spec.yaml
-      - name: Compare the two files
+  build-report:
+    needs: build-oas-artefacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install required tools
+        run: |
+          npm install openapi-diff -g
+      - name: Download OAS file from SOURCE branch
+        uses: actions/download-artifact@v1
+        with:
+          name: original-spec.yaml
+      - name: Download OAS file from TARGET branch
+        uses: actions/download-artifact@v1
+        with:
+          name: modified-spec.yaml
+      - name: Generate report
         run: |
           npx openapi-diff original-spec.yaml modified-spec.yaml | sed -n '1!p' > breaking-changes.json
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -57,10 +57,12 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: original-spec.yaml
+          path: original-spec.yaml
       - name: Download OAS file from TARGET branch
         uses: actions/download-artifact@v1
         with:
           name: modified-spec.yaml
+          path: modified-spec.yaml
       - name: Generate report
         run: |
           npx openapi-diff original-spec.yaml modified-spec.yaml | sed -n '1!p' > breaking-changes.json

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -47,6 +47,7 @@ jobs:
     needs: build-oas-artefacts
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -1,0 +1,36 @@
+name: Source Code API Breaking Changes
+# Everyone is happy with breaking changes ^^
+on:
+  pull_request:
+
+jobs:
+  testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install required tools
+        run: |
+          npm install speccy -g
+          npm install openapi-diff -g
+      - name: Set up env variables
+        run:  |
+          echo "::set-env name=CURRENT_BRANCH::$(echo ${{ github.base_ref }} | sed 's|.*/||')"
+          echo "::set-env name=TARGET_BRANCH::$(echo ${{ github.head_ref }} | sed 's|.*/||')"
+      - name: Clones repository with the two separate branch ( ${{ env.CURRENT_BRANCH }} and ${{ env.TARGET_BRANCH }})
+        run: |
+          git clone -b ${{ env.TARGET_BRANCH }} --depth 1 --single-branch https://github.com/${{ github.repository }}.git A
+          git clone -b ${{ env.CURRENT_BRANCH }} --depth 1 --single-branch https://github.com/${{ github.repository }}.git B
+      - name: Build OAS specifications
+        run: |
+          npx speccy resolve A/api.yml -o original-spec.yaml
+          npx speccy resolve B/api.yml -o modified-spec.yaml
+      - name: Compare the two files
+        run: |
+          npx openapi-diff original-spec.yaml modified-spec.yaml | tail -n +2 > breaking-changes.json
+      - uses: actions/upload-artifact@v1
+        with:
+          name: openapi-diff.json
+          path: breaking-changes.json

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -47,7 +47,6 @@ jobs:
     needs: build-oas-artefacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           npm install speccy -g
           npm install openapi-diff -g
+          npm install -g @openapitools/openapi-generator-cli
       - name: Set up env variables
         run:  |
           echo "::set-env name=CURRENT_BRANCH::$(echo ${{ github.base_ref }} | sed 's|.*/||')"
@@ -23,10 +24,24 @@ jobs:
         run: |
           git clone -b ${{ env.TARGET_BRANCH }} --depth 1 --single-branch https://github.com/${{ github.repository }}.git A
           git clone -b ${{ env.CURRENT_BRANCH }} --depth 1 --single-branch https://github.com/${{ github.repository }}.git B
+      - name: Check if OAS from ${{ env.CURRENT_BRANCH }} is valid
+        run: |
+          npx openapi-generator validate -i B/api.yml
+      - name: Check if OAS from ${{ env.TARGET_BRANCH }} is valid
+        run: |
+          npx openapi-generator validate -i A/api.yml
       - name: Build OAS specifications
         run: |
           npx speccy resolve A/api.yml -o original-spec.yaml
           npx speccy resolve B/api.yml -o modified-spec.yaml
+      - uses: actions/upload-artifact@v1
+        with:
+          name: original-spec.yaml
+          path: original-spec.yaml
+      - uses: actions/upload-artifact@v1
+        with:
+          name: modified-spec.yaml
+          path: modified-spec.yaml
       - name: Compare the two files
         run: |
           npx openapi-diff original-spec.yaml modified-spec.yaml | sed -n '1!p' > breaking-changes.json

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -58,12 +58,10 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: original-spec.yaml
-          path: original-spec.yaml
       - name: Download OAS file from TARGET branch
         uses: actions/download-artifact@v1
         with:
           name: modified-spec.yaml
-          path: modified-spec.yaml
       - name: Generate report
         run: |
           npx openapi-diff original-spec.yaml modified-spec.yaml | sed -n '1!p' > breaking-changes.json

--- a/.github/workflows/documentation-changes.yml
+++ b/.github/workflows/documentation-changes.yml
@@ -29,7 +29,7 @@ jobs:
           npx speccy resolve B/api.yml -o modified-spec.yaml
       - name: Compare the two files
         run: |
-          npx openapi-diff original-spec.yaml modified-spec.yaml | tail -n +2 > breaking-changes.json
+          npx openapi-diff original-spec.yaml modified-spec.yaml | sed -n '1!p' > breaking-changes.json
       - uses: actions/upload-artifact@v1
         with:
           name: openapi-diff.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+  push:
 
 jobs:
   testing:

--- a/controllers/_common/constants.js
+++ b/controllers/_common/constants.js
@@ -1,0 +1,14 @@
+module.exports = {
+    "EXERCISES": {
+        DRAFT: "DRAFT",
+        PENDING: "PENDING",
+        VALIDATED: "VALIDATED",
+        NOT_VALIDATED: "NOT_VALIDATED",
+        ARCHIVED: "ARCHIVED",
+    },
+    "TAGS": {
+        NOT_VALIDATED: "NOT_VALIDATED",
+        VALIDATED: "VALIDATED",
+        DEPRECATED: "DEPRECATED"
+    }
+};

--- a/controllers/_common/exercise_status.js
+++ b/controllers/_common/exercise_status.js
@@ -1,7 +1,0 @@
-module.exports = {
-    DRAFT: "DRAFT",
-    PENDING: "PENDING",
-    VALIDATED: "VALIDATED",
-    NOT_VALIDATED: "NOT_VALIDATED",
-    ARCHIVED: "ARCHIVED",
-};

--- a/controllers/_common/utlis_fct.js
+++ b/controllers/_common/utlis_fct.js
@@ -11,8 +11,7 @@ const uniqWith = require('lodash.uniqwith');
 const isEqual = require('lodash.isequal');
 
 // state
-const exerciseState = require("./constants")["EXERCISES"];
-const tagState = require("./constants")["TAGS"];
+const {TAGS: tagState, EXERCISES: exerciseState} = require("./constants");
 
 // Some utilities functions commonly used
 module.exports = {

--- a/controllers/_common/utlis_fct.js
+++ b/controllers/_common/utlis_fct.js
@@ -11,7 +11,8 @@ const uniqWith = require('lodash.uniqwith');
 const isEqual = require('lodash.isequal');
 
 // state
-const States = require("./exercise_status");
+const exerciseState = require("./constants")["EXERCISES"];
+const tagState = require("./constants")["TAGS"];
 
 // Some utilities functions commonly used
 module.exports = {
@@ -120,7 +121,7 @@ module.exports = {
                 .findAll({
                     attributes: [
                         [
-                            filterGen(`(WHERE "Tag"."isValidated" = true)`),
+                            filterGen(`(WHERE "Tag"."state" = "${tagState.VALIDATED}")`),
                             "total"
                         ]
                     ],
@@ -206,7 +207,7 @@ module.exports = {
                                             really_new_tags.map(tag => {
                                                 return {
                                                     // no matter of the kind of user, creating tags like that should be reviewed
-                                                    isValidated: false,
+                                                    state: tagState.NOT_VALIDATED,
                                                     text: tag.text,
                                                     category_id: tag.category_id,
                                                     // some timestamps must be inserted
@@ -302,7 +303,7 @@ function store_single_exercise(user, exercise_data, existent_tags, really_new_ta
         // optional properties to add
         url: exercise_data.url || null,
         file: (exercise_data.file !== null) ? exercise_data.file.filename : null,
-        state: (exercise_data.state) ? States[exercise_data.state] : States.DRAFT
+        state: (exercise_data.state) ? exerciseState[exercise_data.state] : exerciseState.DRAFT
     };
 
     return new Promise((resolve, reject) => {
@@ -330,7 +331,7 @@ function store_single_exercise(user, exercise_data, existent_tags, really_new_ta
                         really_new_tags.map(tag => {
                             return {
                                 // no matter of the kind of user, creating tags like that should be reviewed
-                                isValidated: false,
+                                state: tagState.NOT_VALIDATED,
                                 text: tag.text,
                                 category_id: tag.category_id,
                                 // some timestamps must be inserted

--- a/controllers/_common/utlis_fct.js
+++ b/controllers/_common/utlis_fct.js
@@ -120,7 +120,7 @@ module.exports = {
                 .findAll({
                     attributes: [
                         [
-                            filterGen(`(WHERE "Tag"."state" = "${tagState.VALIDATED}")`),
+                            filterGen(`(WHERE "Tag"."state" = '${tagState.VALIDATED}')`),
                             "total"
                         ]
                     ],

--- a/controllers/bulk/createMultipleTags.js
+++ b/controllers/bulk/createMultipleTags.js
@@ -1,6 +1,8 @@
 const models = require('../../models');
 const Sequelize = require("sequelize");
 
+const TagState = require("../_common/constants")["TAGS"];
+
 // to prevent duplicates in database
 const {
     find_tag_matches,
@@ -32,9 +34,9 @@ module.exports = (req, res, next) => {
                                 really_new_tags.map(tag => {
                                     return {
                                         // if admin has set explicitly the isValidated
-                                        isValidated: (tag.hasOwnProperty("isValidated"))
-                                            ? tag.isValidated
-                                            : false,
+                                        state: (tag.hasOwnProperty("state"))
+                                            ? TagState[tag.state]
+                                            : TagState.NOT_VALIDATED,
                                         text: tag.text,
                                         category_id: tag.category_id,
                                         // some timestamps must be inserted

--- a/controllers/configurations/fetchOwnConfigurations.js
+++ b/controllers/configurations/fetchOwnConfigurations.js
@@ -10,7 +10,7 @@ module.exports = (req, res, next) => {
         ["id", "tag_id"],
         ["text", "tag_text"],
         "category_id",
-        "isValidated",
+        "state",
         "version"
     ];
 

--- a/controllers/exercises/getExerciseByID.js
+++ b/controllers/exercises/getExerciseByID.js
@@ -1,7 +1,7 @@
 // function for bulky inner select
 const models = require('../../models');
 const {build_search_result} = require("../_common/utlis_fct");
-const enumObj = require("../_common/exercise_status");
+const exerciseState = require("../_common/constants")["EXERCISES"];
 
 module.exports = (req, res, next) => {
 
@@ -22,7 +22,7 @@ module.exports = (req, res, next) => {
             return new Promise((resolve, reject) => {
                 // If exercise is ARCHIVED and this exercise was not access by its creator or admin,
                 // a HTTP error should occur
-                if (result.get("state") === enumObj.ARCHIVED) {
+                if (result.get("state") === exerciseState.ARCHIVED) {
                     const passCriteria = [
                         req.user && req.user.role === "admin",
                         req.user && req.user.role !== "admin" && result.get("user") === req.user.id,

--- a/controllers/exercises/updateExercise.js
+++ b/controllers/exercises/updateExercise.js
@@ -12,7 +12,7 @@ const {
     build_dictionary_for_matching_process,
     matching_process,
 } = require("../_common/utlis_fct");
-const exerciseState = require("../_common/constants")["EXERCISES"];
+const { EXERCISES: exerciseState, TAGS: tagState } = require("../_common/constants");
 
 module.exports = (req, res, next) => {
 
@@ -133,7 +133,7 @@ function insert_new_tags_if_there_is_at_least_one(tags_to_be_inserted, t) {
             .Tag
             .bulkCreate(tags_to_be_inserted.map(tag => ({
                 // no matter of the kind of user, creating tags like that should be reviewed
-                isValidated: false,
+                state: tagState.NOT_VALIDATED,
                 text: tag.text,
                 category_id: tag.category_id,
                 // some timestamps must be inserted

--- a/controllers/exercises/updateExercise.js
+++ b/controllers/exercises/updateExercise.js
@@ -12,7 +12,7 @@ const {
     build_dictionary_for_matching_process,
     matching_process,
 } = require("../_common/utlis_fct");
-const States = require("../_common/exercise_status");
+const exerciseState = require("../_common/constants")["EXERCISES"];
 
 module.exports = (req, res, next) => {
 
@@ -262,7 +262,7 @@ function update_exercise([id, body, t]) {
                     properties["url"] = body.url;
                 }
                 if (body.hasOwnProperty("state")) {
-                    properties["state"] = States[body.state];
+                    properties["state"] = exerciseState[body.state];
                 }
 
                 // user has the possibility to delete/replace his/her own file

--- a/controllers/tags/getTags.js
+++ b/controllers/tags/getTags.js
@@ -9,16 +9,18 @@ module.exports = (req, res, next) => {
     const settings = {
         tags_ids: params.tags_ids || [],
         categories_ids: params.categories_ids || [],
-        state: params.state || "default",
+        state: params.state || [],
         title: params.title || "",
     };
 
     let conditions = [];
 
     // must we include conditions or not
-    if (settings.state !== "default") {
+    if (settings.state.length > 0) {
         conditions.push({
-            isValidated: settings.state === "validated"
+            state: {
+                [Op.in]: settings.state
+            }
         })
     }
     if (settings.tags_ids.length > 0) {

--- a/controllers/tags/submitTagProposal.js
+++ b/controllers/tags/submitTagProposal.js
@@ -2,6 +2,7 @@ const models = require('../../models');
 
 // to prevent duplicates in database
 const {find_tag_matches} = require("../_common/utlis_fct");
+const { TAGS: tagState } = require("../_common/constants");
 
 module.exports = (req, res, next) => {
     const creationDate = new Date();
@@ -22,7 +23,7 @@ module.exports = (req, res, next) => {
                         text: text,
                         category_id: category_id,
                         // by default, consider a tag as not official
-                        isValidated: false,
+                        state: tagState.NOT_VALIDATED,
                         // some date
                         updateAt: creationDate,
                         createAt: creationDate

--- a/controllers/tags/updateTag.js
+++ b/controllers/tags/updateTag.js
@@ -1,12 +1,14 @@
 const models = require('../../models');
 const Sequelize = require("sequelize");
 
+const tagState = require("../_common/constants")["TAGS"];
+
 module.exports = (req, res, next) => {
     const {
         tag_id,
         tag_text,
         category_id,
-        isValidated,
+        state,
         version
     } = req.body;
 
@@ -24,7 +26,7 @@ module.exports = (req, res, next) => {
             return instance.update({
                 category_id: category_id,
                 text: tag_text,
-                isValidated: isValidated
+                state: tagState[state]
             });
         })
         .then(() => {

--- a/controllers/tags_categories/getTagCategories.js
+++ b/controllers/tags_categories/getTagCategories.js
@@ -17,8 +17,9 @@ module.exports = (req, res, next) => {
     //      "Tag_Category"."id",
     //      "Tag_Category"."kind" AS "category",
     //      COUNT(*) FILTER (WHERE "tags"."id" IS NOT NULL) AS "total",
-    //      COUNT(*) FILTER (WHERE "tags"."isValidated" = true) AS "total_validated",
-    //      COUNT(*) FILTER(WHERE "tags"."isValidated" = false) AS "total_unvalidated"
+    //      COUNT(*) FILTER (WHERE "tags"."state" = "VALIDATED") AS "total_validated",
+    //      COUNT(*) FILTER(WHERE "tags"."state" = "NOT_VALIDATED") AS "total_unvalidated"
+    //      COUNT(*) FILTER(WHERE "tags"."state" = "DEPRECATED") AS "total_deprecated"
     // FROM "exercises_library"."Tag_Categories" AS "Tag_Category"
     // LEFT OUTER JOIN "exercises_library"."Tags" AS "tags" ON "Tag_Category"."id" = "tags"."category_id"
     // GROUP BY "Tag_Category"."id", "Tag_Category"."kind";
@@ -39,6 +40,7 @@ module.exports = (req, res, next) => {
                         "total": parseInt(cat.get("total")),
                         "total_validated": parseInt(cat.get("total_validated")),
                         "total_unvalidated": parseInt(cat.get("total_unvalidated")),
+                        "total_deprecated": parseInt(cat.get("total_deprecated")),
                     });
             }))
         )

--- a/controllers/tags_categories/getTagCategoriesWithTags.js
+++ b/controllers/tags_categories/getTagCategoriesWithTags.js
@@ -37,10 +37,11 @@ module.exports = function (req, res, next) {
                     ["id", "tag_id"],
                     ["text", "tag_text"],
                     "category_id",
-                    "isValidated",
+                    "state",
                     "version"
                 ],
                 as: "tags",
+                // TODO
                 where: Object
                     .assign({},
                         ...(

--- a/controllers/tags_categories/getTagCategoriesWithTags.js
+++ b/controllers/tags_categories/getTagCategoriesWithTags.js
@@ -1,12 +1,13 @@
 const models = require('../../models');
 const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
+const {TAGS: TagState} = require("../_common/constants");
 
 module.exports = function (req, res, next) {
     const params = req.query;
 
     const settings = {
-        state: params.state || "default",
+        state: params.state || [],
         onlySelected: params.onlySelected || [],
     };
 
@@ -41,13 +42,16 @@ module.exports = function (req, res, next) {
                     "version"
                 ],
                 as: "tags",
-                // TODO
                 where: Object
                     .assign({},
                         ...(
-                            (settings.state !== "default")
+                            (settings.state.length > 0)
                                 /* istanbul ignore next */
-                                ? [{isValidated: settings.state === "validated"}]
+                                ? [{
+                                    state: {
+                                        [Op.in]: settings.state.map(s => TagState[s] )
+                                    }
+                                }]
                                 : []
                         )
                     )

--- a/middlewares/rules/bulk.js
+++ b/middlewares/rules/bulk.js
@@ -2,6 +2,7 @@ const chain = require('connect-chain-if');
 const {check_credentials_on_exercises} = require("../../controllers/_common/utlis_fct");
 
 const {pass_middleware, check_exercise_state} = require("./common_sub_middlewares");
+const check_user_role = require("../check_user_role");
 
 // Arrays for check
 const check_credentials_endpoints = ["DeleteExercises", "ChangeExercisesStatus"];
@@ -42,6 +43,19 @@ module.exports = (operation) => (req, res, next) => {
                     )
                     .filter(s => s !== undefined)
             ),
+            pass_middleware
+        ),
+        // If endpoint === createMultipleTags , we should check if the user is authorized to include "state" property
+        chain.if(
+            operation["x-operation"] === "createMultipleTags",
+            (_req, _res, _next) => {
+                let allowed = ["user"];
+                // state property is reserved for admin only
+                if (_req.body.some(t => t.hasOwnProperty("state"))) {
+                    allowed.push("admin");
+                }
+                check_user_role(allowed)(_req, _res, _next);
+            },
             pass_middleware
         )
     ])(req, res, (err) => {

--- a/middlewares/rules/bulk.js
+++ b/middlewares/rules/bulk.js
@@ -49,10 +49,10 @@ module.exports = (operation) => (req, res, next) => {
         chain.if(
             operation["x-operation"] === "createMultipleTags",
             (_req, _res, _next) => {
-                let allowed = ["user"];
-                // state property is reserved for admin only
-                if (_req.body.some(t => t.hasOwnProperty("state"))) {
-                    allowed.push("admin");
+                let allowed = ["admin"];
+                // state property is reserved for admin only ; if simple user don't use it - he/she is allowed
+                if (!_req.body.some(t => t.hasOwnProperty("state"))) {
+                    allowed.push("user");
                 }
                 check_user_role(allowed)(_req, _res, _next);
             },

--- a/migrations/20200226152253-replaceIsValidatedByState.js
+++ b/migrations/20200226152253-replaceIsValidatedByState.js
@@ -1,0 +1,46 @@
+'use strict';
+
+let opts = {tableName: 'Tags'};
+const TagState = require("../controllers/_common/constants")["TAGS"];
+const values = Object.values(TagState);
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        // if using a schema
+        let schema;
+        if (queryInterface.sequelize.options.schema) {
+            opts.schema = queryInterface.sequelize.options.schema;
+        }
+        return queryInterface.sequelize.transaction(async (t) => {
+
+            // creates the enum
+            await queryInterface
+                .addColumn(opts, "state", {
+                    type: Sequelize.ENUM(values),
+                    defaultValue: TagState.NOT_VALIDATED
+                }, {transaction: t});
+
+            // populate the db
+            await queryInterface
+                .bulkUpdate(opts.tableName, {
+                    state: TagState.VALIDATED
+                }, {
+                    isValidated: true
+                });
+
+            // destroy old field
+            await queryInterface.removeColumn(opts, "isValidated");
+
+            return Promise.resolve();
+        });
+    },
+
+    down: (queryInterface, Sequelize) => {
+        if (queryInterface.sequelize.options.schema) {
+            opts.schema = queryInterface.sequelize.options.schema;
+        }
+        return Promise.all([
+            queryInterface.removeColumn(opts, "state")
+        ]);
+    }
+};

--- a/migrations/20200226152253-replaceIsValidatedByState.js
+++ b/migrations/20200226152253-replaceIsValidatedByState.js
@@ -7,7 +7,6 @@ const values = Object.values(TagState);
 module.exports = {
     up: (queryInterface, Sequelize) => {
         // if using a schema
-        let schema;
         if (queryInterface.sequelize.options.schema) {
             opts.schema = queryInterface.sequelize.options.schema;
         }
@@ -22,14 +21,14 @@ module.exports = {
 
             // populate the db
             await queryInterface
-                .bulkUpdate(opts.tableName, {
+                .bulkUpdate(opts, {
                     state: TagState.VALIDATED
                 }, {
                     isValidated: true
-                });
+                }, {transaction: t});
 
             // destroy old field
-            await queryInterface.removeColumn(opts, "isValidated");
+            await queryInterface.removeColumn(opts, "isValidated", {transaction: t});
 
             return Promise.resolve();
         });

--- a/models/exercise.js
+++ b/models/exercise.js
@@ -3,8 +3,8 @@
 const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 
-const enumObj = require("../controllers/_common/exercise_status");
-let enumValues = Object.values(enumObj);
+const exerciseState = require("../controllers/_common/constants")["EXERCISES"];
+let enumValues = Object.values(exerciseState);
 
 // Useful for vote filtering (and maybe other things later)
 const OPERATIONS = {
@@ -31,7 +31,7 @@ module.exports = (sequelize, DataTypes) => {
         state: {
             type: DataTypes.ENUM(enumValues),
             allowNull: false,
-            defaultValue: enumObj.DRAFT
+            defaultValue: exerciseState.DRAFT
         },
         url: {
             type: DataTypes.STRING,
@@ -106,7 +106,7 @@ module.exports = (sequelize, DataTypes) => {
                     if (parameters.filterOptions.hasOwnProperty("state")) {
                         criteria.push({
                             state: {
-                                [Op.in]: parameters.filterOptions.state.map(s => enumObj[s])
+                                [Op.in]: parameters.filterOptions.state.map(s => exerciseState[s])
                             }
                         });
                     }

--- a/models/exercise.js
+++ b/models/exercise.js
@@ -111,7 +111,7 @@ module.exports = (sequelize, DataTypes) => {
                         });
                     }
                 }
-                // if the user provide a title / isValidated check , we must add it to the where clause
+                // if the user provide some instructions , we must add them to the where clause
                 if (parameters.hasOwnProperty("data")) {
 
                     /* istanbul ignore else */
@@ -211,14 +211,15 @@ module.exports = (sequelize, DataTypes) => {
                             attributes: [
                                 ["id", "tag_id"],
                                 ["text", "tag_text"],
-                                "isValidated"
+                                "state"
                             ],
                             through: {attributes: []},
                             // Handle the case where no tags exists for one exercise
                             required: false,
                             // if asked, only include some tags (and not all)
                             where:
-                                (!["default", undefined].includes(filterOptions && filterOptions.tags))
+                                (![undefined].includes(filterOptions && filterOptions.tags))
+                                    // TODO
                                     ? {
                                         isValidated: (filterOptions.tags === "validated")
                                     }
@@ -250,12 +251,13 @@ module.exports = (sequelize, DataTypes) => {
                             attributes: [
                                 ["text", "text"],
                                 ["category_id", "category"],
-                                "isValidated"
+                                "state"
                             ],
                             through: {attributes: []},
                             // if asked, only include some tags (and not all)
                             where:
-                                (!["default", undefined].includes(filterOptions && filterOptions.tags))
+                                (![undefined].includes(filterOptions && filterOptions.tags))
+                                    // TODO
                                     ? {
                                         isValidated: (filterOptions.tags === "validated")
                                     }

--- a/models/exercise.js
+++ b/models/exercise.js
@@ -3,7 +3,7 @@
 const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 
-const exerciseState = require("../controllers/_common/constants")["EXERCISES"];
+const { EXERCISES: exerciseState, TAGS: tagState } = require("../controllers/_common/constants");
 let enumValues = Object.values(exerciseState);
 
 // Useful for vote filtering (and maybe other things later)
@@ -219,9 +219,10 @@ module.exports = (sequelize, DataTypes) => {
                             // if asked, only include some tags (and not all)
                             where:
                                 (![undefined].includes(filterOptions && filterOptions.tags))
-                                    // TODO
                                     ? {
-                                        isValidated: (filterOptions.tags === "validated")
+                                        state: {
+                                            [Op.in]: filterOptions.tags.map(s => tagState[s] )
+                                        }
                                     }
                                     : {}
                             ,
@@ -257,9 +258,10 @@ module.exports = (sequelize, DataTypes) => {
                             // if asked, only include some tags (and not all)
                             where:
                                 (![undefined].includes(filterOptions && filterOptions.tags))
-                                    // TODO
                                     ? {
-                                        isValidated: (filterOptions.tags === "validated")
+                                        state: {
+                                            [Op.in]: filterOptions.tags.map(s => tagState[s] )
+                                        }
                                     }
                                     : {}
                             ,

--- a/models/tag.js
+++ b/models/tag.js
@@ -1,15 +1,19 @@
 'use strict';
+
+const tagState = require("../controllers/_common/constants")["TAGS"];
+let enumValues = Object.values(tagState);
+
 module.exports = (sequelize, DataTypes) => {
     let Tag = sequelize.define("Tag", {
         text: {
             type: DataTypes.STRING,
             allowNull: false
         },
-        isValidated: {
-            type: DataTypes.BOOLEAN,
+        state: {
+            type: DataTypes.ENUM(enumValues),
             allowNull: false,
-            defaultValue: false
-        }
+            defaultValue: tagState.NOT_VALIDATED
+        },
     }, {
         // https://sequelize.org/master/manual/models-definition.html#configuration
 
@@ -26,7 +30,7 @@ module.exports = (sequelize, DataTypes) => {
                     ["id", "tag_id"],
                     ["text", "tag_text"],
                     "category_id",
-                    "isValidated",
+                    "state",
                     "version"
                 ]
             }

--- a/models/tag_category.js
+++ b/models/tag_category.js
@@ -42,15 +42,15 @@ module.exports = (sequelize, DataTypes) => {
                             "total"
                         ],
                         [
-                            filterGen(`(WHERE "tags"."state" = "${TagState.VALIDATED}")`),
+                            filterGen(`(WHERE "tags"."state" = '${TagState.VALIDATED}')`),
                             "total_validated"
                         ],
                         [
-                            filterGen(`(WHERE "tags"."state" = "${TagState.NOT_VALIDATED}")`),
+                            filterGen(`(WHERE "tags"."state" = '${TagState.NOT_VALIDATED}')`),
                             "total_unvalidated"
                         ],
                         [
-                            filterGen(`(WHERE "tags"."state" = "${TagState.DEPRECATED}")`),
+                            filterGen(`(WHERE "tags"."state" = '${TagState.DEPRECATED}')`),
                             "total_deprecated"
                         ],
                     ],

--- a/models/tag_category.js
+++ b/models/tag_category.js
@@ -1,5 +1,6 @@
 'use strict';
 const Sequelize = require("sequelize");
+const TagState = require("../controllers/_common/constants")["TAGS"];
 
 module.exports = (sequelize, DataTypes) => {
     let Tag_Category = sequelize.define("Tag_Category", {
@@ -41,12 +42,16 @@ module.exports = (sequelize, DataTypes) => {
                             "total"
                         ],
                         [
-                            filterGen(`(WHERE "tags"."isValidated" = true)`),
+                            filterGen(`(WHERE "tags"."state" = "${TagState.VALIDATED}")`),
                             "total_validated"
                         ],
                         [
-                            filterGen(`(WHERE "tags"."isValidated" = false)`),
+                            filterGen(`(WHERE "tags"."state" = "${TagState.NOT_VALIDATED}")`),
                             "total_unvalidated"
+                        ],
+                        [
+                            filterGen(`(WHERE "tags"."state" = "${TagState.DEPRECATED}")`),
+                            "total_deprecated"
                         ],
                     ],
                     group: ["Tag_Category.id", "Tag_Category.kind"],

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -22,7 +22,7 @@ components:
       description: |
         Status of the exercise into the system. Currently, 5 states are possibles :
 
-        1. DRAFT : The default state (for example when a exercise is inserted into the system)
+        1. DRAFT : The default state (for example when an exercise is inserted into the system)
         2. PENDING : When an exercise is ready for review
         3. VALIDATED : When an exercise is validated by an admin
         4. NOT_VALIDATED : When an exercise is refused by an admin
@@ -36,6 +36,17 @@ components:
 
         1. user : The defaut ( an simple registered user )
         2. admin : User with additional credentials
+    TagState:
+      type: string
+      enum: [NOT_VALIDATED, VALIDATED, DEPRECATED]
+      example: DEPRECATED
+      default: NOT_VALIDATED
+      description: |
+        Status of the tag into the system. Currently, 3 states are possibles :  
+
+        1. NOT_VALIDATED : The default state ( for example when an exercise is inserted into the system)  
+        2. VALIDATED : When a tag is officially recognized
+        3. DEPRECATED : When a tag should not be used anymore
 # To control include for Exercise
     IncludeOptions:
       type: object
@@ -70,11 +81,11 @@ components:
             $ref: "#/components/schemas/State"
           maxItems: 5
         tags:
-          type: string
-          description: |
-            Filter the tags linked to exercise by their validity. The default value ('default') stands for no filtering.
-          enum: ["default", "validated", "pending"]
-          default: "default"
+          type: array
+          description: "Filter the tags linked to exercise by their state. By default, no filtering is done."
+          items:
+            $ref: "#/components/schemas/TagState"
+          maxItems: 3
 # Basic model of a Exercise
     BasicExerciseModel:
       type: object
@@ -234,14 +245,11 @@ components:
               required:
                 - category_text
                 - category_id
-            isValidated:
-              type: boolean
-              default: false
-              example: false
-              description: "Is this tag validated or not ?"
+            state:
+              $ref: "#/components/schemas/TagState"
           required:
             - category
-            - isValidated
+            - state
     TagCategoryWithTags:
       allOf:
         - $ref: "#/components/schemas/Tag_Category"
@@ -285,10 +293,8 @@ components:
               example: 42
               minimum: 0
               description: "the category id to which it is related"
-            isValidated:
-              type: boolean
-              example: false
-              description: "Is this tag validated or not"
+            state:
+              $ref: "#/components/schemas/TagState"
             version:
               type: integer
               minimum: 0
@@ -296,7 +302,7 @@ components:
               example: 42
           required:
             - category_id
-            - isValidated
+            - state
             - version
 # When we want to upload a new exercise, we need other fields for that
     ExerciseForm:

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -40,7 +40,6 @@ components:
       type: string
       enum: [NOT_VALIDATED, VALIDATED, DEPRECATED]
       example: DEPRECATED
-      default: NOT_VALIDATED
       description: |
         Status of the tag into the system. Currently, 3 states are possibles :  
 

--- a/openapi/paths/bulk.yaml
+++ b/openapi/paths/bulk.yaml
@@ -244,6 +244,10 @@ paths:
   /api/bulk/create_tags:
     post:
       summary: "Creates multiple tags into the system"
+      description: |
+        Creates multiple tags into the system.
+
+        Warning : the "state" property can only be used by authorized people (no simple user can use it)
       tags:
         - user
       operationId: createMultipleTags
@@ -263,11 +267,8 @@ paths:
                   - $ref: "../definitions.yaml#/components/schemas/TagProposal"
                   - type: object
                     properties:
-                      isValidated:
-                        type: boolean
-                        example: false
-                        default: false
-                        description: "Should this tag validated or not ? By default, this tag is not validated"
+                      state:
+                        $ref: "../definitions.yaml#/components/schemas/TagState"
       responses:
         '200':
           description: OK

--- a/openapi/paths/exercise.yaml
+++ b/openapi/paths/exercise.yaml
@@ -176,13 +176,10 @@ paths:
                                     example: 42
                                     minimum: 0
                                     description: "The category of this tag"
-                                  isValidated:
-                                    type: boolean
-                                    default: false
-                                    example: false
-                                    description: "Is this tag validated or not ?"
+                                  state:
+                                    $ref: "../definitions.yaml#/components/schemas/TagState"
                                 required:
-                                  - isValidated
+                                  - state
                                   - category
                                   - text
                           required:

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -26,7 +26,7 @@ paths:
               schema:
                 $ref: "../definitions.yaml#/components/schemas/ErrorObject"
     put:
-      summary: "Validate or modify a Tag"
+      summary: "Modify a Tag"
       tags:
         - admin
       operationId: updateTag
@@ -79,10 +79,11 @@ paths:
         - in: query
           name: state
           schema:
-            type: string
-            enum: ["default", "validated", "pending"]
-            default: "default"
-            description: "Filter the tags by their validity. The default value ('default') stands for no filtering."
+            type: array
+            description: "Filter the tags by their state. By default, no filtering is done."
+            items:
+              $ref: "../definitions.yaml#/components/schemas/TagState"
+            maxItems: 3
         - in: query
           name: title
           schema:

--- a/openapi/paths/tags_by_categories.yaml
+++ b/openapi/paths/tags_by_categories.yaml
@@ -11,10 +11,11 @@ paths:
         - in: query
           name: state
           schema:
-            type: string
-            enum: [default, validated, pending]
-            default: default
-            description: "Filter the tags by their validity. The default value ('default') stands for no filtering."
+            type: array
+            description: "Filter the tags by their state. By default, no filtering is done."
+            items:
+              $ref: "../definitions.yaml#/components/schemas/TagState"
+            maxItems: 3
         - in: query
           name: onlySelected
           schema:

--- a/openapi/paths/tags_categories.yaml
+++ b/openapi/paths/tags_categories.yaml
@@ -34,12 +34,16 @@ paths:
                           minimum: 0
                         total_validated:
                           type: integer
-                          description: "The total number of vamodated tags under this tag category"
+                          description: "The total number of VALIDATED tags under this tag category"
                           minimum: 0
                         total_unvalidated:
                           type: integer
-                          description: "The total number of vamodated tags under this tag category"
-                          minimum: 0                        
+                          description: "The total number of NOT_VALIDATED tags under this tag category"
+                          minimum: 0
+                        total_deprecated:
+                          type: integer
+                          description: "The total number of DEPRECATED tags under this tag category"
+                          minimum: 0
                 uniqueItems: true
         # Definition of all error statuses
         default:

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -935,7 +935,7 @@ describe("Complex scenarios", () => {
                 includeMetrics: true
             },
             filterOptions: {
-                "tags": "pending"
+                "tags": ["NOT_VALIDATED", "DEPRECATED"]
             },
             data: {
                 title: "Exercise for delete scenario"
@@ -979,7 +979,7 @@ describe("Complex scenarios", () => {
             .send({
                 filterOptions: {
                     state: ["VALIDATED", "ARCHIVED"],
-                    tags: "pending"
+                    tags: ["VALIDATED", "NOT_VALIDATED" ,"DEPRECATED"]
                 },
                 "orderBy": [
                     // When my issue in Sequelize is fixed, it will restore my tags length sorting :

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -75,7 +75,7 @@ async function setUpBasic() {
             tags.map(tag => ({
                 text: tag,
                 category_id: 1,
-                isValidated: true
+                state: "VALIDATED"
             }))
         );
     expect(response4.status).toBe(200);
@@ -229,7 +229,7 @@ describe("Simple case testing", () => {
     it("GET /api/tags with all settings used", async () => {
         const response = await request
             .get("/api/tags")
-            .query('state=pending')
+            .query('state=NOT_VALIDATED')
             .query('tags_ids=1')
             .query('tags_ids=2')
             .query('categories_ids=' + 1)
@@ -339,7 +339,7 @@ describe("Simple case testing", () => {
             {
                 text: "MASTER_TAG_1",
                 category_id: aTagCategory,
-                isValidated: true,
+                state: "VALIDATED",
             },
             {
                 text: "MASTER_TAG_2",
@@ -1278,7 +1278,23 @@ describe("Validations testing", () => {
             .set('Content-Type', 'application/json')
             .send(some_exercise_data);
         expect(responseTemp.status).toBe(400);
-    })
+    });
+
+    it("POST /api/bulk/create_tags : Simple user cannot create a validated tag", async () => {
+        // creates some tags categories
+        let response = await request
+            .post("/api/bulk/create_tags")
+            .set('Authorization', 'bearer ' + JWT_TOKEN_2)
+            .set('Content-Type', 'application/json')
+            .send(
+                ["TROLL"].map(tag => ({
+                    text: tag,
+                    category_id: 1,
+                    state: "VALIDATED"
+                }))
+            );
+        expect(response.status).toBe(400);
+    });
 });
 
 // utilities functions

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -320,7 +320,8 @@ describe("Simple case testing", () => {
         expect(response.body.every(t => t.hasOwnProperty("total"))).toBeTruthy();
         expect(response.body.every(t => t.hasOwnProperty("total_validated"))).toBeTruthy();
         expect(response.body.every(t => t.hasOwnProperty("total_unvalidated"))).toBeTruthy();
-        expect(response.body.every(t => t.total === (t.total_validated + t.total_unvalidated))).toBeTruthy();
+        expect(response.body.every(t => t.hasOwnProperty("total_deprecated"))).toBeTruthy();
+        expect(response.body.every(t => t.total === (t.total_validated + t.total_unvalidated + t.total_deprecated))).toBeTruthy();
     });
 
     it("POST /api/bulk/create_tags", async () => {

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -1293,7 +1293,7 @@ describe("Validations testing", () => {
                     state: "VALIDATED"
                 }))
             );
-        expect(response.status).toBe(400);
+        expect(response.status).toBe(403);
     });
 });
 

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -242,7 +242,7 @@ describe("Simple case testing", () => {
     it("GET /api/tags_by_categories with all settings used", async () => {
         const response = await request
             .get("/api/tags_by_categories")
-            .query('state=pending')
+            .query('state=VALIDATED')
             .query('onlySelected=1')
             .set('Accept', 'application/json');
         expect(response.status).toBe(200);
@@ -372,7 +372,7 @@ describe("Simple case testing", () => {
                     .some(tag2 =>
                         (tag.text === tag2.tag_text)
                         && (tag2.category_id === aTagCategory)
-                        && (tag2.isValidated === (tag.isValidated || false))
+                        && (tag2.state === (tag.state || "NOT_VALIDATED"))
                     )
             )
         );
@@ -665,7 +665,7 @@ describe("Complex scenarios", () => {
 
         expect(created_tag).not.toBe(undefined);
         expect(created_tag.version).toBe(0);
-        expect(created_tag.isValidated).toBe(false);
+        expect(created_tag.state).toBe("NOT_VALIDATED");
 
         // modify it to validate it
         responseTmp = await request
@@ -677,7 +677,7 @@ describe("Complex scenarios", () => {
                 tag_text: created_tag.tag_text,
                 category_id: created_tag.category_id,
                 version: created_tag.version,
-                isValidated: true
+                state: "VALIDATED"
             });
         expect(responseTmp.status).toBe(200);
 
@@ -1197,7 +1197,7 @@ describe("Validations testing", () => {
                 "tag_id": 0,
                 "tag_text": "SomeTest",
                 "category_id": 0,
-                "isValidated": false,
+                "state": "NOT_VALIDATED",
                 "version": 0
             })
             .expect(403);


### PR DESCRIPTION
This breaking change implies many changes : 

- The state itself is a string enum with the following values : 
  1. NOT_VALIDATED : The default state ( for example when an exercise is inserted into the system)
  2. VALIDATED : When a tag is officially recognized
  3. DEPRECATED : When a tag should not be used anymore  


- The following endpoints that used "isValidated" are impacted : 
   - **/api/exercises/{id}** , **/api/search** and **/api/export**
( simple replacement )
   -  **/api/tags** and **/api/tags_by_categories**
 ( query parameter "state" is replaced by an array of string of this new enum )
   - **/api/bulk/create_tags** ( simple replacement )
   -  **/api/configurations** ( simple replacement )
   - **/api/tags** ( simple replacement )
   - **/api/search** and **/api/export** ( parameters filterOptions -> tags is replaced by an array of string of this new enum )

- Small other thing were done : 
  - new property **total_deprecated** in **/api/tags_categories**
  - rewrite tests to handle this new situation
  - new migration file designed to keep up old data in new format
  - new Github Actions workflow to compare OAS ( so that @dewita has an automated way to know when something changes  )
