### PR TITLE
feat: Allow configurations to have empty tag array

### DIFF
--- a/controllers/configurations/createConfiguration.js
+++ b/controllers/configurations/createConfiguration.js
@@ -21,12 +21,14 @@ module.exports = (req, res, next) => {
                     return models
                         .Configuration_Tag
                         .bulkCreate(
-                            req.body.tags.map(tag => ({
-                                tag_id: tag,
-                                configuration_id: configuration.id
-                            })), {
+                            (req.body.tags || [])
+                                .map(tag => ({
+                                    tag_id: tag,
+                                    configuration_id: configuration.id
+                                })), {
                                 transaction: t
-                            });
+                            }
+                        );
                 });
         })
         .then(() => res.status(200).end())

--- a/controllers/configurations/updateConfiguration.js
+++ b/controllers/configurations/updateConfiguration.js
@@ -42,10 +42,11 @@ module.exports = (req, res, next) => {
                             return models
                                 .Configuration_Tag
                                 .bulkCreate(
-                                    req.body.tags.map(tag => ({
-                                        tag_id: tag,
-                                        configuration_id: configuration.id
-                                    })), {
+                                    (req.body.tags /* istanbul ignore next */ || [])
+                                        .map(tag => ({
+                                            tag_id: tag,
+                                            configuration_id: configuration.id
+                                        })), {
                                         transaction: t
                                     });
                         });

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -594,7 +594,7 @@ components:
           items:
             type: integer
             minimum: 0
-          minItems: 1
+          default: []
       required:
         - name
         - tags

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -594,10 +594,8 @@ components:
           items:
             type: integer
             minimum: 0
-          default: []
       required:
         - name
-        - tags
     ExistentConfiguration:
       allOf:
         - $ref: "#/components/schemas/ConfigurationProposal"

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -236,6 +236,17 @@ describe("Simple case testing", () => {
             .expect(404);
     });
 
+    it("POST /api/configurations with no tags", async () => {
+        await request
+            .post("/api/configurations")
+            .set('Authorization', 'bearer ' + JWT_TOKEN_2)
+            .set('Content-Type', 'application/json')
+            .send({
+                name: "UCLouvain exercises in Java",
+            })
+            .expect(200);
+    });
+
     it("GET /api/tags with all settings used", async () => {
         const response = await request
             .get("/api/tags")


### PR DESCRIPTION
Allow configurations to have empty tag array.
As an result, only the name is still required for creating/updating a configuration